### PR TITLE
convert action constant toUpperCase in reducer_creator

### DIFF
--- a/generator_code_files/rails_style/reducer_creator.js
+++ b/generator_code_files/rails_style/reducer_creator.js
@@ -62,7 +62,7 @@ module.exports = (Model, name) => {
   if (Model.Actions) {
     Model.Actions.forEach(action => {
       cases += `
-		case actions.${action}: {
+		case actions.${action.toUpperCase()}: {
 
 			return { ...state }
 		}


### PR DESCRIPTION
Inside the rails_style generator code, action constants for user-defined actions are incorrectly referenced in camelCase in the generated reducer files, even though they are defined in all caps in the constants file and the actions file. 
This simple change makes sure that the reducer file correctly references the constants inside its switch statement.